### PR TITLE
Stop waiting 15 seconds to check deploy status

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const run = async () => {
         : github.context.sha;
     const MAX_CREATE_TIMEOUT = 60 * 5; // 5 min
     const MAX_WAIT_TIMEOUT = 60 * 15; // 15 min
-    const MAX_READY_TIMEOUT = Number(core.getInput('timeoutSeconds')) || 60;
+    const MAX_READY_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
     const siteId = core.getInput('site_id');
     const context = core.getInput('context');
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const waitForDeployCreation = async (url, commitSha, timeoutSeconds, context) =>
 
 const waitForReadiness = (url, timeoutSeconds) => {
   const startTime = Date.now();
-  const retrySeconds = 15;
+  const retrySeconds = 10;
   let latestDeployState = '(unknown)';
 
   return checkContinually();


### PR DESCRIPTION
In prior code (from forked repo), setInterval was used to retry the request to Netlify to see if a deployment had been created and was ready. Unfortunately, it waited a full interval (e.g. 15 seconds) BEFORE making this request. 

Refactor to make this request right away, and then retry after that. No need to wait before trying to make the request the first time. Also reduce retry intervals (15s -> 5s, 30s -> 10s)

<img width="921" alt="image" src="https://github.com/redwoodmaterials/wait-for-netlify-action/assets/117694460/7aac57e7-74ea-4ef9-b4d3-858834a7d7fc">
